### PR TITLE
#13 : Traduire les etiquettes des exemples

### DIFF
--- a/dictionnaire/templates/dictionary_entry.html
+++ b/dictionnaire/templates/dictionary_entry.html
@@ -84,10 +84,10 @@ le site de référence de la langue cantonaise.
                         <div style="padding-block: 0.25rem; ">
                             {% if source_example.source_language == "yue"%}
                             <span
-                                style="background-color: #AD1F5A; border-radius: 2rem; padding-block: 0.25rem; padding-inline: 0.5rem;">Cantonais</span>
+                                style="background-color: #AD1F5A; border-radius: 2rem; padding-block: 0.25rem; padding-inline: 0.5rem;">{{ _("Cantonais") }}</span>
                             {% elif source_example.source_language == "cmn"%}
                             <span
-                                style="background-color: #0E8B53; border-radius: 2rem; padding-block: 0.25rem; padding-inline: 0.5rem;">Mandarin</span>
+                                style="background-color: #0E8B53; border-radius: 2rem; padding-block: 0.25rem; padding-inline: 0.5rem;">{{ _("Mandarin") }}</span>
                             {% endif %}
                         </div>
                         {{ source_example.traditional.replace("\n", "")|safe }}

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cantonais_org 2.0.0\n"
 "Report-Msgid-Bugs-To: hi@aaronhktan.com\n"
-"POT-Creation-Date: 2025-06-17 15:58-0400\n"
+"POT-Creation-Date: 2025-06-20 15:49-0400\n"
 "PO-Revision-Date: 2025-06-03 01:14-0400\n"
 "Last-Translator: Aaron Tan <hi@aaronhktan.com>\n"
 "Language: en\n"
@@ -33,29 +33,32 @@ msgstr "dictionary./search"
 
 #: dictionnaire/urls.py:58 dictionnaire/views.py:35 templates/index_en.html:49
 #: templates/index_en.html:68 templates/search_bar.html:2
+#: templates/search_bar.html:39
 msgid "auto"
 msgstr "auto"
 
 #: dictionnaire/urls.py:74 dictionnaire/views.py:45 templates/search_bar.html:3
+#: templates/search_bar.html:40
 msgid "traditionnel"
 msgstr "traditional"
 
 #: dictionnaire/urls.py:90 dictionnaire/views.py:55 templates/search_bar.html:4
+#: templates/search_bar.html:41
 msgid "simplifie"
 msgstr "simplified"
 
 #: dictionnaire/urls.py:106 dictionnaire/views.py:65
-#: templates/search_bar.html:5
+#: templates/search_bar.html:5 templates/search_bar.html:42
 msgid "jyutping"
 msgstr "jyutping"
 
 #: dictionnaire/urls.py:122 dictionnaire/views.py:75
-#: templates/search_bar.html:6
+#: templates/search_bar.html:6 templates/search_bar.html:43
 msgid "pinyin"
 msgstr "pinyin"
 
 #: dictionnaire/urls.py:138 dictionnaire/views.py:85 templates/base.html:2
-#: templates/search_bar.html:7
+#: templates/search_bar.html:7 templates/search_bar.html:44
 msgid "fr"
 msgstr "en"
 
@@ -70,13 +73,21 @@ msgstr ""
 "See definitions and examples for %(headword)s on Jyut Dictionary, the "
 "most comprehensive online Cantonese dictionary."
 
-#: dictionnaire/templates/dictionary_entry.html:27
+#: dictionnaire/templates/dictionary_entry.html:31
 msgid "Définitions"
 msgstr "Definitions"
 
-#: dictionnaire/templates/dictionary_entry.html:72
+#: dictionnaire/templates/dictionary_entry.html:77
 msgid "Exemples"
 msgstr "Examples"
+
+#: dictionnaire/templates/dictionary_entry.html:87
+msgid "Cantonais"
+msgstr "Cantonese"
+
+#: dictionnaire/templates/dictionary_entry.html:90
+msgid "Mandarin"
+msgstr "Mandarin"
 
 #: dictionnaire/templates/dictionary_index.html:4 templates/index_fr.html:4
 msgid "Accueil"
@@ -143,17 +154,17 @@ msgid "cantonais.org"
 msgstr "Jyut Dictionary"
 
 #: templates/index_en.html:48 templates/index_en.html:67
-#: templates/search_bar.html:14 templates/search_bar.html:48
+#: templates/search_bar.html:14 templates/search_bar.html:55
 msgid "Sélection de langue"
 msgstr "Language selection"
 
 #: templates/index_en.html:51 templates/index_en.html:70
-#: templates/search_bar.html:16 templates/search_bar.html:50
+#: templates/search_bar.html:16 templates/search_bar.html:57
 msgid "Détection de langue automatique"
 msgstr "Auto-detect search language"
 
 #: templates/index_en.html:55 templates/index_en.html:74
-#: templates/search_bar.html:34 templates/search_bar.html:44
+#: templates/search_bar.html:34 templates/search_bar.html:51
 msgid "Rechercher"
 msgstr "Search"
 
@@ -197,27 +208,27 @@ msgstr "about"
 msgid "À propos"
 msgstr "About"
 
-#: templates/search_bar.html:11 templates/search_bar.html:42
+#: templates/search_bar.html:11 templates/search_bar.html:49
 msgid "Rechercher dans le dictionnaire..."
 msgstr "Search Jyut Dictionary..."
 
-#: templates/search_bar.html:19 templates/search_bar.html:53
+#: templates/search_bar.html:19 templates/search_bar.html:60
 msgid "Caractères traditionnels"
 msgstr "Traditional Chinese"
 
-#: templates/search_bar.html:22 templates/search_bar.html:56
+#: templates/search_bar.html:22 templates/search_bar.html:63
 msgid "Caractères simplifiés"
 msgstr "Simplified Chinese"
 
-#: templates/search_bar.html:25 templates/search_bar.html:59
+#: templates/search_bar.html:25 templates/search_bar.html:66
 msgid "Jyutping"
 msgstr "Jyutping"
 
-#: templates/search_bar.html:28 templates/search_bar.html:62
+#: templates/search_bar.html:28 templates/search_bar.html:69
 msgid "Pinyin"
 msgstr "Pinyin"
 
-#: templates/search_bar.html:31 templates/search_bar.html:65
+#: templates/search_bar.html:31 templates/search_bar.html:72
 msgid "Français"
 msgstr "English"
 


### PR DESCRIPTION
Les exemples ont tous une etiquette qui indique la langue de l'exemple. Ce commit ajoute la traduction pour cette etiquette.