### PR TITLE
#13 : Résoudre une boucle infinie dans la segmentation du Jyutping

### DIFF
--- a/dictionnaire/tests/test_cantonese_utils.py
+++ b/dictionnaire/tests/test_cantonese_utils.py
@@ -69,6 +69,10 @@ class TestJyutpingToYale(TestCase):
         res = cantonese_utils.jyutping_to_yale("mit")
         self.assertEqual(res, "mit")
 
+    def test_malformed_space(self):
+        res = cantonese_utils.jyutping_to_yale("mat 6")
+        self.assertEqual(res, "mat 6")
+
 
 class TestJyutpingToIPA(TestCase):
     def test_simple(self):

--- a/dictionnaire/utils/cantonese_utils.py
+++ b/dictionnaire/utils/cantonese_utils.py
@@ -1089,6 +1089,9 @@ def segment_jyutping(
                     continue
             else:
                 valid_jyutping = False
+                res.append(curr_string)
+                start_idx += 1
+                end_idx += 1
                 continue
 
         if remove_regex_characters:


### PR DESCRIPTION
S'il existe une espace entre une syllabe Jyutping et le ton, l'algorithme qui segmente les syllabes entrerait dans une boucle infinite. Ce commit résout la boucle infinie et ajoute un test unitaire pour éviter ce problème à l'avenir.